### PR TITLE
Return empty array when the target records don't exist

### DIFF
--- a/lib/active_record/precounter.rb
+++ b/lib/active_record/precounter.rb
@@ -13,7 +13,7 @@ module ActiveRecord
     # @return [Array<ActiveRecord::Base>]
     def precount(*association_names)
       records = @relation.to_a
-      return if records.empty?
+      return [] if records.empty?
 
       association_names.each do |association_name|
         association_name = association_name.to_s

--- a/spec/active_record/precounter_spec.rb
+++ b/spec/active_record/precounter_spec.rb
@@ -1,24 +1,39 @@
 RSpec.describe ActiveRecord::Precounter do
   describe '#precount' do
-    before do
-      3.times do |i|
-        tweet = Tweet.create
-        i.times do
-          favorite = Favorite.create(tweet: tweet)
+    context 'When the target records exist' do
+      before do
+        3.times do |i|
+          tweet = Tweet.create
+          i.times do
+            favorite = Favorite.create(tweet: tweet)
+          end
         end
+      end
+
+      after do
+        Tweet.delete_all
+        Favorite.delete_all
+      end
+
+      it 'precounts has_many count properly' do
+        expected = Tweet.all.map { |t| t.favorites.count }
+        expect(
+          ActiveRecord::Precounter.new(Tweet.all).precount(:favorites).map { |t| t.favorites_count }
+        ).to eq(expected)
       end
     end
 
-    after do
-      Tweet.delete_all
-      Favorite.delete_all
-    end
+    context "When the target records don't exist" do
+      after do
+        Tweet.delete_all
+        Favorite.delete_all
+      end
 
-    it 'precounts has_many count properly' do
-      expected = Tweet.all.map { |t| t.favorites.count }
-      expect(
-        ActiveRecord::Precounter.new(Tweet.all).precount(:favorites).map { |t| t.favorites_count }
-      ).to eq(expected)
+      it 'returns empty array' do
+        expect(
+          ActiveRecord::Precounter.new(Tweet.all).precount(:favorites)
+        ).to eq([])
+      end
     end
   end
 end


### PR DESCRIPTION
`#precount` currently returns nil if the target records are empty.

It should be inconvenient to process the returned value.

I fixed this problem to return empty array when the target records are empty.
