### PR TITLE
Fix unexpected subquery

### DIFF
--- a/lib/active_record/precounter.rb
+++ b/lib/active_record/precounter.rb
@@ -27,11 +27,11 @@ module ActiveRecord
         end
 
         count_by_id = if reflection.has_scope?
-                        reflection.scope_for(reflection.klass.where(reflection.inverse_of.name => @relation)).group(
+                        reflection.scope_for(reflection.klass.where(reflection.inverse_of.name => records.map(&:id))).group(
                           reflection.inverse_of.foreign_key
                         ).count
                       else
-                        reflection.klass.where(reflection.inverse_of.name => @relation).group(
+                        reflection.klass.where(reflection.inverse_of.name => records.map(&:id)).group(
                           reflection.inverse_of.foreign_key
                         ).count
                       end


### PR DESCRIPTION
I found different behavior from README.

in README:
```
tweets = Tweet.all
ActiveRecord::Precounter.new(tweets).precount(:favorites)
tweets.each do |tweet|
  p tweet.favorites_count
end
# SELECT `tweets`.* FROM `tweets`
# SELECT COUNT(`favorites`.`tweet_id`), `favorites`.`tweet_id` FROM `favorites` WHERE `favorites`.`tweet_id` IN (1, 2, 3, 4, 5) GROUP BY `favorites`.`tweet_id`
```

but current behavior is below:
```
[tojo@tojo activerecord-precounter]$ rspec
rspec
Using sqlite3

From: /Users/tojo/OSS/tojoqk/activerecord-precounter/spec/active_record/precounter_spec.rb @ line 19 :

    14:         Tweet.delete_all
    15:         Favorite.delete_all
    16:       end
    17: 
    18:       it 'precounts has_many count properly' do
 => 19:         binding.irb
    20:         expected = Tweet.all.map { |t| t.favorites.count }
    21:         expect(
    22:           ActiveRecord::Precounter.new(Tweet.all).precount(:favorites).map { |t| t.favorites_count }
    23:         ).to eq(expected)
    24:       end

>> ActiveRecord::Base.logger = Logger.new(STDOUT)
ActiveRecord::Base.logger = Logger.new(STDOUT)
=> #<Logger:0x00007f9778d0d6f0 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x00007f9778d0d6a0 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x00007f9778d0d650 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @mon_owner=nil, @mon_count=0, @mon_mutex=#<Thread::Mutex:0x00007f9778d0d5d8>>>
>> tweets = Tweet.all
ActiveRecord::Precounter.new(tweets).precount(:favorites)
tweets.each do |tweet|
  p tweet.favorites_count
end
tweets = Tweet.all
D, [2018-06-20T12:34:21.333557 #94922] DEBUG -- :   Tweet Load (0.2ms)  SELECT  "tweets".* FROM "tweets" LIMIT ?  [["LIMIT", 11]]
=> #<ActiveRecord::Relation [#<Tweet id: 1, created_at: "2018-06-20 03:34:10", updated_at: "2018-06-20 03:34:10">, #<Tweet id: 2, created_at: "2018-06-20 03:34:10", updated_at: "2018-06-20 03:34:10">, #<Tweet id: 3, created_at: "2018-06-20 03:34:10", updated_at: "2018-06-20 03:34:10">]>
>> ActiveRecord::Precounter.new(tweets).precount(:favorites)
D, [2018-06-20T12:34:21.399845 #94922] DEBUG -- :   Tweet Load (0.2ms)  SELECT "tweets".* FROM "tweets"
D, [2018-06-20T12:34:21.401491 #94922] DEBUG -- :    (0.2ms)  SELECT COUNT(*) AS count_all, "favorites"."tweet_id" AS favorites_tweet_id FROM "favorites" WHERE "favorites"."tweet_id" IN (SELECT "tweets"."id" FROM "tweets") GROUP BY "favorites"."tweet_id"
=> [#<Tweet id: 1, created_at: "2018-06-20 03:34:10", updated_at: "2018-06-20 03:34:10">, #<Tweet id: 2, created_at: "2018-06-20 03:34:10", updated_at: "2018-06-20 03:34:10">, #<Tweet id: 3, created_at: "2018-06-20 03:34:10", updated_at: "2018-06-20 03:34:10">]
>> tweets.each do |tweet|
?>   p tweet.favorites_count
>> end
0
1
2
```

```
SELECT COUNT(*) AS count_all, "favorites"."tweet_id" AS favorites_tweet_id FROM "favorites" WHERE "favorites"."tweet_id" IN (SELECT "tweets"."id" FROM "tweets") GROUP BY "favorites"."tweet_id"
```
it differs from behavior of README.

So, I request to fix this to below:
```
[tojo@tojo activerecord-precounter]$ rspec
rspec
Using sqlite3

From: /Users/tojo/OSS/tojoqk/activerecord-precounter/spec/active_record/precounter_spec.rb @ line 19 :

    14:         Tweet.delete_all
    15:         Favorite.delete_all
    16:       end
    17: 
    18:       it 'precounts has_many count properly' do
 => 19:         binding.irb
    20:         expected = Tweet.all.map { |t| t.favorites.count }
    21:         expect(
    22:           ActiveRecord::Precounter.new(Tweet.all).precount(:favorites).map { |t| t.favorites_count }
    23:         ).to eq(expected)
    24:       end

>> ActiveRecord::Base.logger = Logger.new(STDOUT)
ActiveRecord::Base.logger = Logger.new(STDOUT)
=> #<Logger:0x00007fe120c59f78 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x00007fe120c59f28 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x00007fe120c59ed8 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @mon_owner=nil, @mon_count=0, @mon_mutex=#<Thread::Mutex:0x00007fe120c59e60>>>
>> tweets = Tweet.all
ActiveRecord::Precounter.new(tweets).precount(:favorites)
tweets.each do |tweet|
  p tweet.favorites_count
end
tweets = Tweet.all
D, [2018-06-20T12:35:42.135151 #95391] DEBUG -- :   Tweet Load (0.2ms)  SELECT  "tweets".* FROM "tweets" LIMIT ?  [["LIMIT", 11]]
=> #<ActiveRecord::Relation [#<Tweet id: 1, created_at: "2018-06-20 03:35:37", updated_at: "2018-06-20 03:35:37">, #<Tweet id: 2, created_at: "2018-06-20 03:35:37", updated_at: "2018-06-20 03:35:37">, #<Tweet id: 3, created_at: "2018-06-20 03:35:37", updated_at: "2018-06-20 03:35:37">]>
>> ActiveRecord::Precounter.new(tweets).precount(:favorites)
D, [2018-06-20T12:35:42.214971 #95391] DEBUG -- :   Tweet Load (0.2ms)  SELECT "tweets".* FROM "tweets"
D, [2018-06-20T12:35:42.216707 #95391] DEBUG -- :    (0.3ms)  SELECT COUNT(*) AS count_all, "favorites"."tweet_id" AS favorites_tweet_id FROM "favorites" WHERE "favorites"."tweet_id" IN (?, ?, ?) GROUP BY "favorites"."tweet_id"  [["tweet_id", 1], ["tweet_id", 2], ["tweet_id", 3]]
=> [#<Tweet id: 1, created_at: "2018-06-20 03:35:37", updated_at: "2018-06-20 03:35:37">, #<Tweet id: 2, created_at: "2018-06-20 03:35:37", updated_at: "2018-06-20 03:35:37">, #<Tweet id: 3, created_at: "2018-06-20 03:35:37", updated_at: "2018-06-20 03:35:37">]
>> tweets.each do |tweet|
?>   p tweet.favorites_count
>> end
0
1
2
=> [#<Tweet id: 1, created_at: "2018-06-20 03:35:37", updated_at: "2018-06-20 03:35:37">, #<Tweet id: 2, created_at: "2018-06-20 03:35:37", updated_at: "2018-06-20 03:35:37">, #<Tweet id: 3, created_at: "2018-06-20 03:35:37", updated_at: "2018-06-20 03:35:37">]
```

```
SELECT COUNT(*) AS count_all, "favorites"."tweet_id" AS favorites_tweet_id FROM "favorites" WHERE "favorites"."tweet_id" IN (?, ?, ?) GROUP BY "favorites"."tweet_id"  [["tweet_id", 1], ["tweet_id", 2], ["tweet_id", 3]]
```
I think it is expected behavior.

Best regards.