### PR TITLE
Fix scoped count

### DIFF
--- a/lib/active_record/precounter.rb
+++ b/lib/active_record/precounter.rb
@@ -27,7 +27,7 @@ module ActiveRecord
         end
 
         count_by_id = if reflection.has_scope?
-                        reflection.scope_for(reflection.klass.where(reflection.inverse_of.name => records.map(&:id))).group(
+                        reflection.scope_for(reflection.klass).where(reflection.inverse_of.name => records.map(&:id)).group(
                           reflection.inverse_of.foreign_key
                         ).count
                       else


### PR DESCRIPTION
Pass klass to `ActiveRecord::Reflection::MacroReflection#scoped_for` instead of passing relation because older versions of that method only accept klass.

- https://github.com/rails/rails/blob/v5.0.7/activerecord/lib/active_record/reflection.rb#L314-L316
- https://github.com/rails/rails/blob/v5.2.0/activerecord/lib/active_record/reflection.rb#L396-L398