### PR TITLE
Use pg gem instead of deprecated postgres gem

### DIFF
--- a/activerecord-precounter.gemspec
+++ b/activerecord-precounter.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord', '>= 5'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'mysql2'
-  spec.add_development_dependency 'postgres'
+  spec.add_development_dependency 'pg'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'sqlite3'


### PR DESCRIPTION
```
$ bundle install
(snip)
Post-install message from postgres:
---------------------------------------------------------------------------

This is an old, deprecated version of the Ruby PostgreSQL driver that hasn't
been maintained or supported since early 2008.

You should install/require 'pg' instead.

If you need the 'postgres' gem for legacy code that can't be converted, you can
still install it using an explicit version, like so:

  gem install postgres -v '0.7.9.2008.01.28'
  gem uninstall postgres -v '>0.7.9.2008.01.28'

If you have any questions, the nice folks in the Google group can help:

  http://goo.gl/OjOPP / ruby-pg@googlegroups.com

---------------------------------------------------------------------------
```