### PR TITLE
support primary key option

### DIFF
--- a/spec/active_record/precounter_spec.rb
+++ b/spec/active_record/precounter_spec.rb
@@ -53,5 +53,30 @@ RSpec.describe ActiveRecord::Precounter do
         ).to eq([[4, 2]])
       end
     end
+
+    context "When the target records has a primary_key option" do
+      before do
+        3.times do |i|
+          Tweet.create(another_id: i)
+          i.times do
+            Favorite.create( another_id: i)
+          end
+        end
+      end
+
+      after do
+        Tweet.delete_all
+        Favorite.delete_all
+      end
+
+      it 'returns correct records' do
+        precounter = ActiveRecord::Precounter.new(Tweet.all)
+        expected = Tweet.all.map { |t| t.another_associated_favorites.count }
+
+        expect(
+          precounter.precount(:another_associated_favorites).map(&:another_associated_favorites_count)
+        ).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/models/favorite.rb
+++ b/spec/models/favorite.rb
@@ -1,4 +1,8 @@
 class Favorite < ActiveRecord::Base
   belongs_to :tweet
+  belongs_to :another_associated_tweet,
+             primary_key: :another_id, foreign_key: :another_id,
+             class_name: "Tweet"
+
   scope :active, -> { where(active: true) }
 end

--- a/spec/models/tweet.rb
+++ b/spec/models/tweet.rb
@@ -2,4 +2,7 @@ class Tweet < ActiveRecord::Base
   has_many :favorites
   has_many :active_favorites,
            -> { active }, class_name: "Favorite", inverse_of: :tweet
+  has_many :another_associated_favorites,
+           primary_key: :another_id, foreign_key: :another_id,
+           class_name: "Favorite", inverse_of: :another_associated_tweet
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -1,12 +1,16 @@
 ActiveRecord::Schema.define do
   create_table :favorites, force: true do |t|
     t.integer  :tweet_id
+    t.integer  :another_id
     t.boolean :active
     t.timestamps null: false
   end
   add_index :favorites, :tweet_id
+  add_index :favorites, :another_id
 
   create_table :tweets, force: true do |t|
+    t.integer  :another_id
     t.timestamps null: false
   end
+  add_index :tweets, :another_id, unique: true
 end


### PR DESCRIPTION
## Before fixed

assosications.count and precount do not match.

assosications.count use primary key.
precount use id.

```
Failures:

  1) ActiveRecord::Precounter#precount When the target records has a primary_key option returns correct records
     Failure/Error:
       expect(
         precounter.precount(:another_associated_favorites).map(&:another_associated_favorites_count)
       ).to eq(expected)
     
       expected: [0, 1, 2]
            got: [0, 0, 0]
     
       (compared using ==)
     # ./spec/active_record/precounter_spec.rb:76:in `block (4 levels) in <top (required)>'
```

## After fixed

To match.

```
Finished in 0.11335 seconds (files took 1.01 seconds to load)
4 examples, 0 failures
```

## When there is no primary key option

There is no problem, because the primary key of klass is used. 
Id is used.

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/reflection.rb#L469-L471

```
def association_primary_key(klass = nil)
  options[:primary_key] || primary_key(klass || self.klass)
end
```