### PR TITLE
Use define_singleton_method instead of defining class attribute

### DIFF
--- a/lib/active_record/precountable.rb
+++ b/lib/active_record/precountable.rb
@@ -1,0 +1,20 @@
+module ActiveRecord
+  module Precountable
+    class NotPrecountedError < StandardError
+    end
+
+    def precounts(*association_names)
+      association_names.each do |association_name|
+        var_name = "#{association_name}_count"
+        instance_var_name = "@#{var_name}"
+
+        attr_writer(var_name)
+        define_method(var_name) do
+          count = instance_variable_get(instance_var_name)
+          raise NotPrecountedError.new("`#{association_name}' not precounted") unless count
+          count
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/precounter.rb
+++ b/lib/active_record/precounter.rb
@@ -47,28 +47,14 @@ module ActiveRecord
                         ).count
                       end
 
-        writer = define_count_accessor(records.first, association_name)
+        reader_name = "#{association_name}_count"
         records.each do |record|
-          record.public_send(writer, count_by_id.fetch(record.public_send(primary_key), 0))
+          record.define_singleton_method(reader_name) do
+            count_by_id.fetch(record.public_send(primary_key), 0)
+          end
         end
       end
       records
-    end
-
-    private
-
-    # @param [ActiveRecord::Base] record
-    # @param [String] association_name
-    # @return [String] writer method name
-    def define_count_accessor(record, association_name)
-      reader_name = "#{association_name}_count"
-      writer_name = "#{reader_name}="
-
-      if !record.respond_to?(reader_name) && !record.respond_to?(writer_name)
-        record.class.send(:attr_accessor, reader_name)
-      end
-
-      writer_name
     end
   end
 end

--- a/lib/active_record/precounter.rb
+++ b/lib/active_record/precounter.rb
@@ -47,13 +47,28 @@ module ActiveRecord
                         ).count
                       end
 
-        reader_name = "#{association_name}_count"
+        writer = define_count_accessor(records.first, association_name)
         records.each do |record|
-          count = count_by_id.fetch(record.public_send(primary_key), 0)
-          record.define_singleton_method(reader_name) { count }
+          record.public_send(writer, count_by_id.fetch(record.public_send(primary_key), 0))
         end
       end
       records
+    end
+
+    private
+
+    # @param [ActiveRecord::Base] record
+    # @param [String] association_name
+    # @return [String] writer method name
+    def define_count_accessor(record, association_name)
+      reader_name = "#{association_name}_count"
+      writer_name = "#{reader_name}="
+
+      if !record.respond_to?(reader_name) && !record.respond_to?(writer_name)
+        record.class.send(:attr_accessor, reader_name)
+      end
+
+      writer_name
     end
   end
 end

--- a/lib/active_record/precounter.rb
+++ b/lib/active_record/precounter.rb
@@ -49,9 +49,8 @@ module ActiveRecord
 
         reader_name = "#{association_name}_count"
         records.each do |record|
-          record.define_singleton_method(reader_name) do
-            count_by_id.fetch(record.public_send(primary_key), 0)
-          end
+          count = count_by_id.fetch(record.public_send(primary_key), 0)
+          record.define_singleton_method(reader_name) { count }
         end
       end
       records

--- a/spec/active_record/precounter_spec.rb
+++ b/spec/active_record/precounter_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe ActiveRecord::Precounter do
           ActiveRecord::Precounter.new(Tweet.find(tweet.id)).precount(:favorites).map { |t| t.favorites_count }
         ).to eq([expected])
       end
+
+      it 'only adds the count attribute for the precounted records' do
+        ActiveRecord::Precounter.new(Tweet.first)
+        expect { Tweet.first.favorites_count }.to raise_error(NoMethodError, /undefined method `favorites_count'/)
+      end
     end
 
     context "When the target records don't exist" do

--- a/spec/active_record/precounter_spec.rb
+++ b/spec/active_record/precounter_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe ActiveRecord::Precounter do
         ).to eq([expected])
       end
 
-      it 'only adds the count attribute for the precounted records' do
+      it 'raises if a record was not precounted' do
         ActiveRecord::Precounter.new(Tweet.first)
-        expect { Tweet.first.favorites_count }.to raise_error(NoMethodError, /undefined method `favorites_count'/)
+        expect { Tweet.first.favorites_count }.to raise_error(ActiveRecord::Precountable::NotPrecountedError, /`favorites' not precounted/)
       end
     end
 


### PR DESCRIPTION
I was receiving inconsistent test results based on their run order. Sometimes tests would raise NoMethodErrors for `*_count` methods if they didn't precount, but ran _before_ tests that precounted.

I noticed that the current implementation defines attr_accessor on the object's class, which persisted between tests. This actually lead to an error in production because we had forgotten to precount in an area that depended on the precounted keys, and even though it was tested, the test did not catch it because the attributes existed from a previous test case.

What do you think of only defining the attribute only the objects that got precounted, using `define_singleton_method`? This way we'll get predictable failures if `*_count` is called on an object that hadn't first been precounted, and we can also reliably test for `respond_to?(:*_count)` to see if it's been precounted or not and if it's safe to call it (rather than having to check if it responds to `*_count` _and_ isn't `nil`).